### PR TITLE
Fix the PDC descriptor pack value

### DIFF
--- a/code/libs/dvbobjects/dvbobjects/DVB/Descriptors.py
+++ b/code/libs/dvbobjects/dvbobjects/DVB/Descriptors.py
@@ -449,7 +449,7 @@ class PDC_descriptor(Descriptor):
     descriptor_tag = 0x69
 
     def bytes(self):
-        fmt = "!BH"
+        fmt = "!BL"
         return pack(fmt,
                     (0xF0) | (self.day >> 1),
 		    (self.day << 15) | (self.month << 11) | (self.hour << 6) | (self.minute),


### PR DESCRIPTION
H is not the right format for the date, the value can have 20 bits, the format should be L
