### PR TITLE
subtitling_descriptor Fix

### DIFF
--- a/code/libs/dvbobjects/dvbobjects/DVB/Descriptors.py
+++ b/code/libs/dvbobjects/dvbobjects/DVB/Descriptors.py
@@ -548,9 +548,8 @@ class subtitling_descriptor(Descriptor):
 		    self.subtitling_data_descriptor_loop),
 		    "")
 		    
-	fmt = "!B%ds" % len(data_bytes)
+	fmt = "!%ds" % len(data_bytes)
 	return pack(fmt,
-	    len(data_bytes),
 	    data_bytes,
 		)
 


### PR DESCRIPTION
ETSI EN 300 468, Table 99,  'length' should not be included.
Solution tested